### PR TITLE
Move HDL IP metadata template

### DIFF
--- a/templates/COCOTB_TESTBENCH_TEMPLATE.py
+++ b/templates/COCOTB_TESTBENCH_TEMPLATE.py
@@ -1,0 +1,20 @@
+# cocotb testbench template for HDL IP
+import cocotb
+from cocotb.triggers import RisingEdge
+
+async def source(dut):
+    """Drive stimulus to the DUT."""
+    # TODO: add driving logic
+    await RisingEdge(dut.clk)
+
+async def drain(dut):
+    """Consume outputs from the DUT."""
+    # TODO: add checking logic
+    await RisingEdge(dut.clk)
+
+@cocotb.test()
+async def run_test(dut):
+    """Example test that uses source and drain."""
+    await source(dut)
+    await drain(dut)
+

--- a/templates/HDL_IP_METADATA_TEMPLATE.txt
+++ b/templates/HDL_IP_METADATA_TEMPLATE.txt
@@ -1,0 +1,7 @@
+// HDL IP Metadata Header
+// Copy and fill in these fields at the top of your HDL file.
+// IP Name       :
+// Inputs Desc   :
+// Outputs Desc  :
+// Author        :
+// Rev Number    :


### PR DESCRIPTION
## Summary
- remove old metadata template from repo root
- add new comment-style metadata header in `templates/`
- add cocotb testbench template with source & drain skeleton

## Testing
- `pytest -q`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856039a1ae4832b9c2ea3cff3e62701